### PR TITLE
Added controller preset support

### DIFF
--- a/Code/Converter/BlueprintConverter/BlueprintConverter.cpp
+++ b/Code/Converter/BlueprintConverter/BlueprintConverter.cpp
@@ -4,6 +4,8 @@
 #include "ObjectDatabase/DatabaseConfig.hpp"
 #include "ObjectDatabase/ProgCounter.hpp"
 
+#include "Converter/Entity/ControllerParser.hpp"
+#include "Converter/Entity/ControllerTransform.hpp"
 #include "Converter/ConvertSettings.hpp"
 #include "Converter/MtlFileWriter.hpp"
 
@@ -259,20 +261,34 @@ void BlueprintConv::ConvertToModel(
 	SMBlueprint::AddObjectFunction v_add_obj_func = BlueprintConv::GetAddObjectFunction();
 	SMBlueprint* v_pBlueprint = nullptr;
 
+	// Reuse parsed DOM for controller presets to avoid double-parsing
+	const bool v_needPresets = BlueprintConverterSettings::ApplyControllerPresets;
+	simdjson::dom::document v_bpDoc;
+	simdjson::dom::document* v_pDocOut = v_needPresets ? &v_bpDoc : nullptr;
+
 	if (pCustomGame)
 	{
 		SMModCustomGameSwitch<true, false> v_content_switch;
 		v_content_switch.MergeContent(pCustomGame);
 
-		v_pBlueprint = SMBlueprint::FromFileWithStatus(bp_path, v_add_obj_func, error);
+		v_pBlueprint = SMBlueprint::FromFileWithStatus(bp_path, v_add_obj_func, error, v_pDocOut);
 	}
 	else
 	{
-		v_pBlueprint = SMBlueprint::FromFileWithStatus(bp_path, v_add_obj_func, error);
+		v_pBlueprint = SMBlueprint::FromFileWithStatus(bp_path, v_add_obj_func, error, v_pDocOut);
 	}
 
 	if (v_pBlueprint)
 	{
+		if (v_needPresets && !error)
+		{
+			const auto v_bpRoot = v_bpDoc.root();
+			ControllerPresetData v_presetData = ControllerParser::ExtractPresets(v_bpRoot);
+			auto v_bodyGraph = ControllerParser::BuildBodyGraph(
+				v_bpRoot, v_presetData, v_pBlueprint->m_childToBodyIndex);
+			ControllerTransform::Apply(v_pBlueprint, v_bodyGraph, v_pBlueprint->m_childToBodyIndex);
+		}
+
 		BlueprintConv::WriteToFileInternal(v_pBlueprint, bp_name, error);
 
 		//Since all the sorted groups are attached to the blueprint, the blueprint takes care of all the allocated memory

--- a/Code/Converter/ConvertSettings.hpp
+++ b/Code/Converter/ConvertSettings.hpp
@@ -26,6 +26,7 @@ private:
 struct BlueprintConverterSettings
 {
 	inline static int SeparationType = 0;
+	inline static bool ApplyControllerPresets = false;
 
 private:
 	BlueprintConverterSettings() = default;

--- a/Code/Converter/Entity/Block.cpp
+++ b/Code/Converter/Entity/Block.cpp
@@ -182,7 +182,7 @@ void SMBlock::WriteObjectToFile(
 	Model v_blockModel;
 	FillCustomCube(v_blockModel, m_size / 2.0f, m_position, m_parent->m_tiling);
 
-	const glm::mat4 v_blockTransform = transform * this->GetTransformMatrix();
+	const glm::mat4 v_blockTransform = transform * m_preTransform * this->GetTransformMatrix();
 	v_blockModel.WriteToFile(v_blockTransform, offset, file, this);
 
 	ProgCounter::ProgressValue++;

--- a/Code/Converter/Entity/Blueprint.cpp
+++ b/Code/Converter/Entity/Blueprint.cpp
@@ -146,11 +146,13 @@ SMBlueprint* SMBlueprint::FromFile(
 SMBlueprint* SMBlueprint::FromFileWithStatus(
 	const std::wstring_view& path,
 	SMBlueprint::AddObjectFunction v_addObjFunc,
-	ConvertError& error)
+	ConvertError& error,
+	simdjson::dom::document* pDocOut)
 {
 	ProgCounter::SetState(ProgState::ParsingBlueprint, 0);
 
-	simdjson::dom::document v_bp_doc;
+	simdjson::dom::document v_localDoc;
+	simdjson::dom::document& v_bp_doc = pDocOut ? *pDocOut : v_localDoc;
 	if (!JsonReader::LoadParseSimdjsonC(path, v_bp_doc, simdjson::dom::element_type::OBJECT))
 	{
 		error.setError(1, "Couldn't read the specified blueprint file. Possible reason: Invalid file, Parse error, Invalid path");
@@ -408,6 +410,7 @@ void SMBlueprint::LoadBodiesWithCounter(const simdjson::dom::element& v_blueprin
 
 		for (const auto v_child : v_childs_array)
 		{
+			m_childToBodyIndex[m_objectIndex] = m_bodyIndex;
 			this->LoadChild(v_child);
 
 			ProgCounter::ProgressValue++;
@@ -447,6 +450,7 @@ void SMBlueprint::LoadBodies(const simdjson::dom::element& pJson)
 
 		for (const auto v_child : v_childs_array.get_array().value_unsafe())
 		{
+			m_childToBodyIndex[m_objectIndex] = m_bodyIndex;
 			this->LoadChild(v_child);
 			m_objectIndex++;
 		}

--- a/Code/Converter/Entity/Blueprint.hpp
+++ b/Code/Converter/Entity/Blueprint.hpp
@@ -10,6 +10,8 @@
 #include "Utils/clr_include.hpp"
 #include "Utils/Json.hpp"
 
+#include <unordered_map>
+
 SM_UNMANAGED_CODE
 
 class SMBlueprint final : public SMEntity
@@ -32,7 +34,7 @@ public:
 	static SMBlueprint* LoadAutomatic(const std::string_view& str, const glm::vec3& pos, const glm::quat& rot);
 	static SMBlueprint* FromFile(const std::wstring_view& path, const glm::vec3& pos, const glm::quat& rot);
 	//Used by blueprint converter as it reports the conversion status
-	static SMBlueprint* FromFileWithStatus(const std::wstring_view& path, AddObjectFunction v_addObjFunc, ConvertError& v_error);
+	static SMBlueprint* FromFileWithStatus(const std::wstring_view& path, AddObjectFunction v_addObjFunc, ConvertError& v_error, simdjson::dom::document* pDocOut = nullptr);
 	static SMBlueprint* FromJsonString(const std::string_view& json_str, const glm::vec3& pos, const glm::quat& rot);
 
 	EntityType Type() const override;
@@ -40,6 +42,8 @@ public:
 	void WriteObjectToFile(std::ofstream& file, WriterOffsetData& offset, const glm::mat4& transform) const override;
 	std::size_t GetAmountOfObjects() const override;
 	void CalculateCenterPoint(glm::vec3& outInput) const override;
+
+	static glm::vec3 JsonToVector(const simdjson::simdjson_result<simdjson::dom::element>& vec_json);
 
 	/*
 		This vector contains blocks, parts and joints
@@ -52,8 +56,6 @@ private:
 
 	static void AddObject_Default(SMBlueprint* self, SMEntity* pEntity);
 
-	static glm::vec3 JsonToVector(const simdjson::simdjson_result<simdjson::dom::element>& vec_json);
-
 	void LoadChild(const simdjson::dom::element& v_child);
 	void LoadJoint(const simdjson::dom::element& v_jnt);
 
@@ -65,6 +67,10 @@ private:
 
 	std::size_t m_objectIndex;
 	std::size_t m_bodyIndex;
+
+public:
+	// child index -> body index (for controller presets)
+	std::unordered_map<std::size_t, std::size_t> m_childToBodyIndex;
 };
 
 SM_MANAGED_CODE

--- a/Code/Converter/Entity/Body.cpp
+++ b/Code/Converter/Entity/Body.cpp
@@ -84,3 +84,20 @@ std::size_t SMBody::GetAmountOfObjects() const
 {
 	return m_objects.size();
 }
+
+void SMBody::ApplyPreTransformByBodyMap(
+	const std::unordered_map<std::size_t, glm::mat4>& bodyTransforms,
+	const std::unordered_map<std::size_t, std::size_t>& childToBodyMap)
+{
+	for (SMEntity* v_pEntity : m_objects)
+	{
+		const std::size_t v_entityIdx = v_pEntity->GetIndex();
+		const auto v_bodyIt = childToBodyMap.find(v_entityIdx);
+		if (v_bodyIt == childToBodyMap.end()) continue;
+
+		const auto v_transformIt = bodyTransforms.find(v_bodyIt->second);
+		if (v_transformIt == bodyTransforms.end()) continue;
+
+		v_pEntity->SetPreTransform(v_transformIt->second);
+	}
+}

--- a/Code/Converter/Entity/Body.hpp
+++ b/Code/Converter/Entity/Body.hpp
@@ -9,6 +9,8 @@
 #include "UStd/UnmanagedString.hpp"
 #include "UStd/UnmanagedVector.hpp"
 
+#include <unordered_map>
+
 SM_UNMANAGED_CODE
 
 class SMBody : public SMEntity
@@ -28,6 +30,10 @@ public:
 
 	void CalculateCenterPoint(glm::vec3& outInput) const override;
 	std::size_t GetAmountOfObjects() const override;
+
+	void ApplyPreTransformByBodyMap(
+		const std::unordered_map<std::size_t, glm::mat4>& bodyTransforms,
+		const std::unordered_map<std::size_t, std::size_t>& childToBodyMap);
 
 private:
 	std::vector<SMEntity*> m_objects;

--- a/Code/Converter/Entity/ControllerData.hpp
+++ b/Code/Converter/Entity/ControllerData.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Utils/GlmUnmanaged.hpp"
+#include "Utils/clr_include.hpp"
+
+#include <unordered_map>
+
+SM_UNMANAGED_CODE
+
+struct ControllerPresetData
+{
+	// joint_id -> angle in degrees (negated if reverse)
+	std::unordered_map<std::size_t, float> bearingAngles;
+	// controller_id -> extension in notches
+	std::unordered_map<std::size_t, float> pistonSettings;
+};
+
+struct JointConnection
+{
+	std::size_t parentBodyIdx;
+	std::size_t childBodyIdx;
+	glm::mat4 localTransform{ 1.0f }; // identity if no preset
+	bool hasPreset = false;
+};
+
+SM_MANAGED_CODE

--- a/Code/Converter/Entity/ControllerParser.cpp
+++ b/Code/Converter/Entity/ControllerParser.cpp
@@ -1,0 +1,202 @@
+#include "ControllerParser.hpp"
+
+#include "Converter/Entity/Blueprint.hpp"
+#include "ObjectDatabase/ObjectRotations.hpp"
+#include "Utils/Console.hpp"
+
+SM_UNMANAGED_CODE
+
+ControllerPresetData ControllerParser::ExtractPresets(const simdjson::dom::element& blueprint)
+{
+	ControllerPresetData v_result;
+
+	const auto v_bodies = blueprint["bodies"];
+	if (!v_bodies.is_array()) return v_result;
+
+	for (const auto v_body : v_bodies.get_array().value_unsafe())
+	{
+		const auto v_childs = v_body["childs"];
+		if (!v_childs.is_array()) continue;
+
+		for (const auto v_child : v_childs.get_array().value_unsafe())
+		{
+			if (!v_child.is_object()) continue;
+
+			const auto v_controller = v_child["controller"];
+			if (!v_controller.is_object()) continue;
+
+			// controller.joints[].{id, startAngle, reverse}
+			const auto v_joints = v_controller["joints"];
+			if (v_joints.is_array())
+			{
+				for (const auto v_jnt : v_joints.get_array().value_unsafe())
+				{
+					if (!v_jnt.is_object()) continue;
+
+					const auto v_id = v_jnt["id"];
+					const auto v_startAngle = v_jnt["startAngle"];
+
+					if (!v_id.is_number()) continue;
+
+					const std::size_t v_jointId = JsonReader::GetNumber<std::size_t>(v_id.value_unsafe());
+					const float v_angle = v_startAngle.is_number()
+						? JsonReader::GetNumber<float>(v_startAngle.value_unsafe())
+						: 0.0f;
+
+					if (v_angle != 0.0f)
+					{
+						const auto v_reverse = v_jnt["reverse"];
+						const bool v_isReverse = v_reverse.is_bool()
+							&& v_reverse.get_bool().value_unsafe();
+
+						v_result.bearingAngles[v_jointId] = v_isReverse ? -v_angle : v_angle;
+					}
+				}
+			}
+
+			// controller.controllers[].{id, frames[0].setting}
+			const auto v_controllers = v_controller["controllers"];
+			if (v_controllers.is_array())
+			{
+				for (const auto v_ctrl : v_controllers.get_array().value_unsafe())
+				{
+					if (!v_ctrl.is_object()) continue;
+
+					const auto v_id = v_ctrl["id"];
+					if (!v_id.is_number()) continue;
+
+					const std::size_t v_ctrlId = JsonReader::GetNumber<std::size_t>(v_id.value_unsafe());
+
+					const auto v_frames = v_ctrl["frames"];
+					if (!v_frames.is_array()) continue;
+
+					const auto v_framesArray = v_frames.get_array().value_unsafe();
+					if (v_framesArray.size() == 0) continue;
+
+					const auto v_firstFrame = *v_framesArray.begin();
+					if (!v_firstFrame.is_object()) continue;
+
+					const auto v_setting = v_firstFrame["setting"];
+					if (!v_setting.is_number()) continue;
+
+					const float v_settingVal = JsonReader::GetNumber<float>(v_setting.value_unsafe());
+					if (v_settingVal != 0.0f)
+						v_result.pistonSettings[v_ctrlId] = v_settingVal;
+				}
+			}
+		}
+	}
+
+	return v_result;
+}
+
+static glm::mat4 ComputeBearingTransform(
+	unsigned char xzRotation,
+	const glm::vec3& position,
+	float angleDegrees)
+{
+	const glm::mat4 v_rotMat = Rotations::GetRotationMatrix(xzRotation);
+	const glm::vec3 v_axis = glm::vec3(v_rotMat * glm::vec4(0.0f, 0.0f, 1.0f, 0.0f));
+	const float v_radians = glm::radians(-angleDegrees);
+
+	// Pivot at the center of the bearing's grid cell
+	const glm::vec3 v_pivot = position + glm::vec3(0.5f, 0.5f, 0.5f);
+
+	return glm::translate(v_pivot)
+		* glm::rotate(v_radians, v_axis)
+		* glm::translate(-v_pivot);
+}
+
+static glm::mat4 ComputePistonTransform(
+	unsigned char xzRotation,
+	float settingNotches)
+{
+	const glm::mat4 v_rotMat = Rotations::GetRotationMatrix(xzRotation);
+	const glm::vec3 v_dir = glm::vec3(v_rotMat * glm::vec4(0.0f, 0.0f, 1.0f, 0.0f));
+	const float v_offset = settingNotches * 0.25f;
+
+	return glm::translate(v_dir * v_offset);
+}
+
+std::vector<JointConnection> ControllerParser::BuildBodyGraph(
+	const simdjson::dom::element& blueprint,
+	const ControllerPresetData& presetData,
+	const std::unordered_map<std::size_t, std::size_t>& childToBodyMap)
+{
+	std::vector<JointConnection> v_result;
+
+	const auto v_joints = blueprint["joints"];
+	if (!v_joints.is_array()) return v_result;
+
+	const auto v_jointsArray = v_joints.get_array().value_unsafe();
+	v_result.reserve(v_jointsArray.size());
+
+	for (const auto v_jnt : v_jointsArray)
+	{
+		if (!v_jnt.is_object()) continue;
+
+		const auto v_childA = v_jnt["childA"];
+		const auto v_childB = v_jnt["childB"];
+		const auto v_id = v_jnt["id"];
+
+		if (!(v_childA.is_number() && v_childB.is_number() && v_id.is_number()))
+			continue;
+
+		const std::size_t v_childAIdx = JsonReader::GetNumber<std::size_t>(v_childA.value_unsafe());
+		const std::size_t v_childBIdx = JsonReader::GetNumber<std::size_t>(v_childB.value_unsafe());
+
+		const auto v_parentIt = childToBodyMap.find(v_childAIdx);
+		const auto v_childIt = childToBodyMap.find(v_childBIdx);
+		if (v_parentIt == childToBodyMap.end() || v_childIt == childToBodyMap.end())
+			continue;
+
+		if (v_parentIt->second == v_childIt->second)
+			continue;
+
+		JointConnection v_conn;
+		v_conn.parentBodyIdx = v_parentIt->second;
+		v_conn.childBodyIdx = v_childIt->second;
+
+		const std::size_t v_jointId = JsonReader::GetNumber<std::size_t>(v_id.value_unsafe());
+
+		const auto v_xAxis = v_jnt["xaxisA"];
+		const auto v_zAxis = v_jnt["zaxisA"];
+		const int v_xAxisInt = v_xAxis.is_number() ? JsonReader::GetNumber<int>(v_xAxis.value_unsafe()) : 1;
+		const int v_zAxisInt = v_zAxis.is_number() ? JsonReader::GetNumber<int>(v_zAxis.value_unsafe()) : 3;
+		const unsigned char v_xzRotation = Rotations::CompressRotation(v_xAxisInt, v_zAxisInt);
+
+		const auto v_bearingIt = presetData.bearingAngles.find(v_jointId);
+		if (v_bearingIt != presetData.bearingAngles.end())
+		{
+			const glm::vec3 v_posVec = SMBlueprint::JsonToVector(v_jnt["posA"]);
+			v_conn.localTransform = ComputeBearingTransform(v_xzRotation, v_posVec, v_bearingIt->second);
+			v_conn.hasPreset = true;
+			v_result.push_back(v_conn);
+			continue;
+		}
+
+		// Piston presets are matched via the joint's own controller.id
+		const auto v_jntController = v_jnt["controller"];
+		if (v_jntController.is_object())
+		{
+			const auto v_ctrlId = v_jntController["id"];
+			if (v_ctrlId.is_number())
+			{
+				const std::size_t v_controllerId = JsonReader::GetNumber<std::size_t>(v_ctrlId.value_unsafe());
+				const auto v_pistonIt = presetData.pistonSettings.find(v_controllerId);
+				if (v_pistonIt != presetData.pistonSettings.end())
+				{
+					v_conn.localTransform = ComputePistonTransform(v_xzRotation, v_pistonIt->second);
+					v_conn.hasPreset = true;
+					v_result.push_back(v_conn);
+					continue;
+				}
+			}
+		}
+
+		// Still needed for hierarchy traversal even without a preset
+		v_result.push_back(v_conn);
+	}
+
+	return v_result;
+}

--- a/Code/Converter/Entity/ControllerParser.cpp
+++ b/Code/Converter/Entity/ControllerParser.cpp
@@ -113,9 +113,7 @@ static glm::mat4 ComputePistonTransform(
 {
 	const glm::mat4 v_rotMat = Rotations::GetRotationMatrix(xzRotation);
 	const glm::vec3 v_dir = glm::vec3(v_rotMat * glm::vec4(0.0f, 0.0f, 1.0f, 0.0f));
-	const float v_offset = settingNotches * 0.25f;
-
-	return glm::translate(v_dir * v_offset);
+	return glm::translate(v_dir * settingNotches);
 }
 
 std::vector<JointConnection> ControllerParser::BuildBodyGraph(

--- a/Code/Converter/Entity/ControllerParser.hpp
+++ b/Code/Converter/Entity/ControllerParser.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "ControllerData.hpp"
+
+#include "Utils/clr_include.hpp"
+#include "Utils/Json.hpp"
+
+#include <unordered_map>
+#include <vector>
+
+SM_UNMANAGED_CODE
+
+namespace ControllerParser
+{
+	ControllerPresetData ExtractPresets(const simdjson::dom::element& blueprint);
+
+	std::vector<JointConnection> BuildBodyGraph(
+		const simdjson::dom::element& blueprint,
+		const ControllerPresetData& presetData,
+		const std::unordered_map<std::size_t, std::size_t>& childToBodyMap);
+}
+
+SM_MANAGED_CODE

--- a/Code/Converter/Entity/ControllerTransform.cpp
+++ b/Code/Converter/Entity/ControllerTransform.cpp
@@ -1,0 +1,126 @@
+#include "ControllerTransform.hpp"
+
+#include "Converter/Entity/Blueprint.hpp"
+#include "Converter/Entity/Body.hpp"
+
+#include "Utils/Console.hpp"
+
+#include <algorithm>
+
+SM_UNMANAGED_CODE
+
+void ControllerTransform::Apply(
+	SMBlueprint* pBlueprint,
+	const std::vector<JointConnection>& bodyGraph,
+	const std::unordered_map<std::size_t, std::size_t>& childToBodyMap)
+{
+	if (bodyGraph.empty()) return;
+
+	// Root heuristic: score = (parentBody refs) - (childBody refs), highest wins
+	std::unordered_map<std::size_t, int> v_rootScore;
+	for (const auto& v_conn : bodyGraph)
+	{
+		v_rootScore[v_conn.parentBodyIdx]++;
+		v_rootScore[v_conn.childBodyIdx]--;
+	}
+
+	std::unordered_map<std::size_t, std::size_t> v_entityCount;
+	for (const auto& [v_entityIdx, v_bodyIdx] : childToBodyMap)
+		v_entityCount[v_bodyIdx]++;
+
+	std::size_t v_rootBody = bodyGraph[0].parentBodyIdx;
+	bool v_foundRoot = false;
+	int v_bestScore = 0;
+	std::size_t v_bestEntityCount = 0;
+
+	for (const auto& [v_bodyIdx, v_score] : v_rootScore)
+	{
+		const auto v_ecIt = v_entityCount.find(v_bodyIdx);
+		const std::size_t v_entCount = (v_ecIt != v_entityCount.end()) ? v_ecIt->second : 0;
+
+		if (!v_foundRoot
+			|| v_score > v_bestScore
+			|| (v_score == v_bestScore && v_entCount > v_bestEntityCount))
+		{
+			v_rootBody = v_bodyIdx;
+			v_bestScore = v_score;
+			v_bestEntityCount = v_entCount;
+			v_foundRoot = true;
+		}
+	}
+
+	struct Edge
+	{
+		std::size_t targetBody;
+		glm::mat4 transform;
+		bool hasPreset;
+	};
+
+	std::unordered_map<std::size_t, std::vector<Edge>> v_adjList;
+	for (const auto& v_conn : bodyGraph)
+	{
+		v_adjList[v_conn.parentBodyIdx].push_back(
+			{ v_conn.childBodyIdx, v_conn.localTransform, v_conn.hasPreset });
+		v_adjList[v_conn.childBodyIdx].push_back(
+			{ v_conn.parentBodyIdx, glm::inverse(v_conn.localTransform), v_conn.hasPreset });
+	}
+
+	// Preset edges first so BFS prefers joints that carry a transform
+	for (auto& [v_bodyIdx, v_edges] : v_adjList)
+	{
+		std::stable_partition(v_edges.begin(), v_edges.end(),
+			[](const Edge& e) { return e.hasPreset; });
+	}
+
+	// v_bodyTransforms doubles as visited set
+	std::unordered_map<std::size_t, glm::mat4> v_bodyTransforms;
+	v_bodyTransforms.reserve(v_rootScore.size());
+	v_bodyTransforms[v_rootBody] = glm::mat4(1.0f);
+
+	std::vector<std::size_t> v_queue;
+	v_queue.reserve(v_rootScore.size());
+	v_queue.push_back(v_rootBody);
+	std::size_t v_queueIdx = 0;
+
+	while (v_queueIdx < v_queue.size())
+	{
+		const std::size_t v_cur = v_queue[v_queueIdx++];
+		const glm::mat4& v_curTransform = v_bodyTransforms[v_cur];
+
+		const auto v_adjIt = v_adjList.find(v_cur);
+		if (v_adjIt == v_adjList.end()) continue;
+
+		for (const auto& v_edge : v_adjIt->second)
+		{
+			if (v_bodyTransforms.contains(v_edge.targetBody))
+				continue;
+
+			v_bodyTransforms[v_edge.targetBody] = v_curTransform * v_edge.transform;
+			v_queue.push_back(v_edge.targetBody);
+		}
+	}
+
+	v_bodyTransforms.erase(v_rootBody);
+
+	if (v_bodyTransforms.empty()) return;
+
+	for (SMEntity* v_pEntity : pBlueprint->m_objects)
+	{
+		if (v_pEntity->Type() == EntityType::Body)
+		{
+			SMBody* v_pBody = static_cast<SMBody*>(v_pEntity);
+			v_pBody->ApplyPreTransformByBodyMap(v_bodyTransforms, childToBodyMap);
+		}
+		else
+		{
+			const std::size_t v_entityIdx = v_pEntity->GetIndex();
+			const auto v_bodyIt = childToBodyMap.find(v_entityIdx);
+			if (v_bodyIt == childToBodyMap.end()) continue;
+
+			const auto v_transformIt = v_bodyTransforms.find(v_bodyIt->second);
+			if (v_transformIt == v_bodyTransforms.end()) continue;
+
+			v_pEntity->SetPreTransform(v_transformIt->second);
+		}
+	}
+}

--- a/Code/Converter/Entity/ControllerTransform.hpp
+++ b/Code/Converter/Entity/ControllerTransform.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "ControllerData.hpp"
+
+#include "Utils/clr_include.hpp"
+
+#include <unordered_map>
+#include <vector>
+
+SM_UNMANAGED_CODE
+
+class SMBlueprint;
+
+namespace ControllerTransform
+{
+	void Apply(
+		SMBlueprint* pBlueprint,
+		const std::vector<JointConnection>& bodyGraph,
+		const std::unordered_map<std::size_t, std::size_t>& childToBodyMap);
+}
+
+SM_MANAGED_CODE

--- a/Code/Converter/Entity/Entity.cpp
+++ b/Code/Converter/Entity/Entity.cpp
@@ -219,7 +219,7 @@ void SMEntityWithModel::WriteObjectToFile(
 	WriterOffsetData& offset,
 	const glm::mat4& transform) const
 {
-	const glm::mat4 model_matrix = transform * this->GetTransformMatrix();
+	const glm::mat4 model_matrix = transform * m_preTransform * this->GetTransformMatrix();
 
 	m_model->WriteToFile(model_matrix, offset, file, this);
 

--- a/Code/Converter/Entity/Entity.hpp
+++ b/Code/Converter/Entity/Entity.hpp
@@ -104,10 +104,14 @@ public:
 	// This option can help you to discard unwanted sub meshes (like shadow only sub meshes)
 	virtual bool GetCanWrite(const std::string_view& name, const std::size_t idx) const;
 
+	void SetPreTransform(const glm::mat4& t) noexcept { m_preTransform = t; }
+	const glm::mat4& GetPreTransform() const noexcept { return m_preTransform; }
+
 protected:
 	glm::vec3 m_position;
 	glm::quat m_rotation;
 	glm::vec3 m_size;
+	glm::mat4 m_preTransform{ 1.0f };
 };
 
 class SMC_NOVTABLE SMEntityWithUuid : public SMEntity

--- a/Code/Converter/Entity/Wedge.cpp
+++ b/Code/Converter/Entity/Wedge.cpp
@@ -181,7 +181,7 @@ void SMWedge::WriteObjectToFile(
 	const glm::mat4 v_localTransform = this->GetTransformMatrix();
 	FillCustomCube(v_newWedge, v_localTransform, m_size * 0.5f, m_position, m_parentBlock->m_tiling);
 
-	const glm::mat4 v_wedgeTransform = transform * v_localTransform;
+	const glm::mat4 v_wedgeTransform = transform * m_preTransform * v_localTransform;
 	v_newWedge.WriteToFile(v_wedgeTransform, offset, file, this);
 
 	ProgCounter::ProgressValue++;

--- a/Code/QtGui/ConvSettings/BlueprintConvertSettingsGui.cpp
+++ b/Code/QtGui/ConvSettings/BlueprintConvertSettingsGui.cpp
@@ -9,6 +9,7 @@ void BlueprintConverterThreadData::applySettings() const
 {
 	this->applySettingsBase();
 	BlueprintConverterSettings::SeparationType = this->separation_type;
+	BlueprintConverterSettings::ApplyControllerPresets = this->apply_controller_presets;
 }
 
 //////////BLUEPRINT CONVERTER SETTINGS GUI/////////
@@ -20,6 +21,7 @@ BlueprintConverterSettingsGui::BlueprintConverterSettingsGui(
 )
 	: ConverterSettingsGuiBase(parent, filename)
 	, m_cbSeparationType(this)
+	, m_blueprintOptions(this)
 	, m_modelSettings(this)
 	, m_cbCustomGameContent(this, path)
 {
@@ -44,8 +46,14 @@ BlueprintConverterSettingsGui::BlueprintConverterSettingsGui(
 	m_cbSeparationType.m_comboBox->setCurrentIndex(
 		BlueprintConverterSettings::SeparationType);
 
+	m_blueprintOptions.setTitle("Blueprint Options");
+	m_bApplyControllerPresets = new QCheckBox("Apply Controller Presets", &m_blueprintOptions);
+	m_bApplyControllerPresets->setChecked(BlueprintConverterSettings::ApplyControllerPresets);
+	m_blueprintOptions.m_layout->addWidget(m_bApplyControllerPresets);
+
 	m_objectLayout->addWidget(&m_objectName, 0, Qt::AlignTop);
 	m_objectLayout->addWidget(&m_cbSeparationType, 0, Qt::AlignTop);
+	m_objectLayout->addWidget(&m_blueprintOptions, 0, Qt::AlignTop);
 	m_objectLayout->addWidget(&m_modelSettings, 0, Qt::AlignTop);
 	m_objectLayout->addWidget(&m_cbCustomGameContent, 0, Qt::AlignTop);
 	m_objectLayout->addWidget(m_convertButton, 0, Qt::AlignBottom);
@@ -60,6 +68,7 @@ void BlueprintConverterSettingsGui::getThreadData(BlueprintConverterThreadData* 
 	
 	data->custom_game_idx.value = m_cbCustomGameContent.getCustomGameIndex();
 	data->separation_type = m_cbSeparationType.m_comboBox->currentIndex();
+	data->apply_controller_presets = m_bApplyControllerPresets->isChecked();
 
 	m_modelSettings.fillSettings(&data->model_settings);
 }

--- a/Code/QtGui/ConvSettings/BlueprintConvertSettingsGui.hpp
+++ b/Code/QtGui/ConvSettings/BlueprintConvertSettingsGui.hpp
@@ -22,6 +22,7 @@ public:
 public:
 	CustomGameIndex custom_game_idx;
 	int separation_type;
+	bool apply_controller_presets = false;
 };
 
 class BlueprintConverterSettingsGui : public ConverterSettingsGuiBase
@@ -37,6 +38,8 @@ public:
 
 private:
 	NamedComboBox m_cbSeparationType;
+	AlignedGroupBox m_blueprintOptions;
+	QCheckBox* m_bApplyControllerPresets;
 	ModelSettingsBox m_modelSettings;
 	CustomGameSelector m_cbCustomGameContent;
 };

--- a/SM-Converter.vcxproj
+++ b/SM-Converter.vcxproj
@@ -180,6 +180,8 @@ xcopy /y /d "$(SolutionDir)Dependencies\Assimp\DLL\assimp$(PlatformArchitecture)
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='ReleaseDebugInfo|x64'">true</CompileAsManaged>
     </ClCompile>
     <ClCompile Include="Code\Converter\Entity\Body.cpp" />
+    <ClCompile Include="Code\Converter\Entity\ControllerParser.cpp" />
+    <ClCompile Include="Code\Converter\Entity\ControllerTransform.cpp" />
     <ClCompile Include="Code\Converter\Entity\Decal.cpp">
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</CompileAsManaged>
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</CompileAsManaged>
@@ -400,6 +402,9 @@ xcopy /y /d "$(SolutionDir)Dependencies\Assimp\DLL\assimp$(PlatformArchitecture)
     <ClInclude Include="Code\Converter\Entity\Block.hpp" />
     <ClInclude Include="Code\Converter\Entity\Blueprint.hpp" />
     <ClInclude Include="Code\Converter\Entity\Body.hpp" />
+    <ClInclude Include="Code\Converter\Entity\ControllerData.hpp" />
+    <ClInclude Include="Code\Converter\Entity\ControllerParser.hpp" />
+    <ClInclude Include="Code\Converter\Entity\ControllerTransform.hpp" />
     <ClInclude Include="Code\Converter\Entity\Decal.hpp" />
     <ClInclude Include="Code\Converter\Entity\GroundTerrainData.hpp" />
     <ClInclude Include="Code\Converter\Entity\Harvestable.hpp" />

--- a/SM-Converter.vcxproj.filters
+++ b/SM-Converter.vcxproj.filters
@@ -216,6 +216,12 @@
     <ClCompile Include="Code\Converter\Entity\Body.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Code\Converter\Entity\ControllerParser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Code\Converter\Entity\ControllerTransform.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Code\ObjectDatabase\SubMeshData.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -432,6 +438,15 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Code\Converter\Entity\Body.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Code\Converter\Entity\ControllerData.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Code\Converter\Entity\ControllerParser.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Code\Converter\Entity\ControllerTransform.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Code\Utils\GlmUnmanaged.hpp">

--- a/SMConverterCLI.vcxproj
+++ b/SMConverterCLI.vcxproj
@@ -106,6 +106,8 @@ xcopy /y /d "$(SolutionDir)Dependencies\Assimp\DLL\assimp$(PlatformArchitecture)
     <ClCompile Include="Code\Converter\Entity\Block.cpp" />
     <ClCompile Include="Code\Converter\Entity\Blueprint.cpp" />
     <ClCompile Include="Code\Converter\Entity\Body.cpp" />
+    <ClCompile Include="Code\Converter\Entity\ControllerParser.cpp" />
+    <ClCompile Include="Code\Converter\Entity\ControllerTransform.cpp" />
     <ClCompile Include="Code\Converter\Entity\Decal.cpp" />
     <ClCompile Include="Code\Converter\Entity\Entity.cpp" />
     <ClCompile Include="Code\Converter\Entity\Harvestable.cpp" />
@@ -172,6 +174,9 @@ xcopy /y /d "$(SolutionDir)Dependencies\Assimp\DLL\assimp$(PlatformArchitecture)
     <ClInclude Include="Code\Converter\Entity\Block.hpp" />
     <ClInclude Include="Code\Converter\Entity\Blueprint.hpp" />
     <ClInclude Include="Code\Converter\Entity\Body.hpp" />
+    <ClInclude Include="Code\Converter\Entity\ControllerData.hpp" />
+    <ClInclude Include="Code\Converter\Entity\ControllerParser.hpp" />
+    <ClInclude Include="Code\Converter\Entity\ControllerTransform.hpp" />
     <ClInclude Include="Code\Converter\Entity\Decal.hpp" />
     <ClInclude Include="Code\Converter\Entity\Entity.hpp" />
     <ClInclude Include="Code\Converter\Entity\GroundTerrainData.hpp" />

--- a/SMConverterCLI.vcxproj.filters
+++ b/SMConverterCLI.vcxproj.filters
@@ -147,6 +147,12 @@
     <ClCompile Include="Code\Converter\Entity\Body.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Code\Converter\Entity\ControllerParser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Code\Converter\Entity\ControllerTransform.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Code\Converter\Entity\Decal.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -345,6 +351,15 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Code\Converter\Entity\Body.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Code\Converter\Entity\ControllerData.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Code\Converter\Entity\ControllerParser.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Code\Converter\Entity\ControllerTransform.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Code\Converter\Entity\Decal.hpp">

--- a/SMConverterQt.vcxproj
+++ b/SMConverterQt.vcxproj
@@ -147,6 +147,8 @@ xcopy /y /d "$(SolutionDir)Media\icon.ico" "$(SolutionDir)Build\$(ProjectName)-$
     <ClCompile Include="Code\Converter\Entity\Block.cpp" />
     <ClCompile Include="Code\Converter\Entity\Blueprint.cpp" />
     <ClCompile Include="Code\Converter\Entity\Body.cpp" />
+    <ClCompile Include="Code\Converter\Entity\ControllerParser.cpp" />
+    <ClCompile Include="Code\Converter\Entity\ControllerTransform.cpp" />
     <ClCompile Include="Code\Converter\Entity\Decal.cpp" />
     <ClCompile Include="Code\Converter\Entity\Entity.cpp" />
     <ClCompile Include="Code\Converter\Entity\Harvestable.cpp" />
@@ -233,6 +235,9 @@ xcopy /y /d "$(SolutionDir)Media\icon.ico" "$(SolutionDir)Build\$(ProjectName)-$
     <ClInclude Include="Code\Converter\Entity\Block.hpp" />
     <ClInclude Include="Code\Converter\Entity\Blueprint.hpp" />
     <ClInclude Include="Code\Converter\Entity\Body.hpp" />
+    <ClInclude Include="Code\Converter\Entity\ControllerData.hpp" />
+    <ClInclude Include="Code\Converter\Entity\ControllerParser.hpp" />
+    <ClInclude Include="Code\Converter\Entity\ControllerTransform.hpp" />
     <ClInclude Include="Code\Converter\Entity\Decal.hpp" />
     <ClInclude Include="Code\Converter\Entity\Entity.hpp" />
     <ClInclude Include="Code\Converter\Entity\GroundTerrainData.hpp" />

--- a/SMConverterQt.vcxproj.filters
+++ b/SMConverterQt.vcxproj.filters
@@ -260,6 +260,12 @@
     <ClCompile Include="Code\Converter\Entity\Body.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Code\Converter\Entity\ControllerParser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Code\Converter\Entity\ControllerTransform.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Code\Utils\Color.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -440,6 +446,15 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Code\Converter\Entity\Body.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Code\Converter\Entity\ControllerData.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Code\Converter\Entity\ControllerParser.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Code\Converter\Entity\ControllerTransform.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Code\Converter\Entity\Decal.hpp">


### PR DESCRIPTION
Added the ability to pre-apply controller preset bearing rotations and piston extensions onto the exported model.
To use this, simply check `Apply Controller Presets` when converting a blueprint.

**Why this was made:**
I frequently convert vehicles and mechs from the workshop, and these creations tend to rely heavily on controller + bearing setups for shaping body panels, steering columns, and other structural details. Since the tool currently exports everything in its resting state, I'd have to manually set origins and rotate parts in Blender to match how they actually look in-game — which gets tedious pretty quickly. So I decided to implement this.

**How it works:**
Full disclosure — I have zero programming experience, but I do have some experience with AI-assisted coding. This was implemented entirely using the Claude Code CLI tool with the Claude Opus 4.6 model, followed by multiple rounds of AI-driven code review. Please bear with me on that front.
During blueprint loading, the JSON `controller` fields are parsed to extract bearing pre-rotation angles and piston extension settings. A body hierarchy graph is then built from the `joints` connection data, and BFS is used starting from the root body to accumulate transformation matrices layer by layer. The resulting transforms are then applied to every entity belonging to the corresponding body. The entire process reuses the already-parsed JSON DOM, so no redundant file parsing is needed.
Five new files were added (`ControllerData.hpp`, `ControllerParser.hpp/cpp`, `ControllerTransform.hpp/cpp`), along with a `m_preTransform` matrix on the `SMEntity` base class that gets injected during OBJ writing. The feature is off by default and only takes effect when enabled — existing conversion behavior is completely unaffected.

**How it was tested:**
*Built and tested with MSVC v143 (VS 2022) on Windows 11, Release configuration.*
Tested with several high-quality vehicle blueprints and mech blueprints from the workshop, as well as small purpose-built test blueprints. Everything works as expected, with no major or obvious issues found so far.
One minor issue: the scoring heuristic for identifying the root body may not be optimal in all cases — on certain mechs, most parts are oriented correctly but the feet may end up not being perpendicular to the ground. That said, this doesn't significantly detract from the overall usefulness of the feature.

**Screenshots:**
2000 GT classic sports car (pop-up headlights, steering wheel, exhaust pipes):
<img width="1729" height="1089" alt="image" src="https://github.com/user-attachments/assets/d27a6a61-7659-46f7-aff5-4d228182abf4" />
<img width="1964" height="1080" alt="image" src="https://github.com/user-attachments/assets/c31f0b35-40c8-47c8-8966-a9b488f6ab36" />
Porsche (A-pillar, steering wheel):
<img width="1724" height="1092" alt="image" src="https://github.com/user-attachments/assets/1e98c2f3-9318-4cc9-aab1-bc3c10b58314" />
Titan mech:
<img width="1764" height="1309" alt="image" src="https://github.com/user-attachments/assets/360bdd18-06fc-4027-8ee6-42db267f9a1e" />
<img width="1747" height="1339" alt="image" src="https://github.com/user-attachments/assets/54d03eae-7fe9-4a6d-a1e7-763d445eba29" />

**UI change:**
Added a new setting, placed separately from the existing ones:
<img width="1062" height="1073" alt="image" src="https://github.com/user-attachments/assets/df0a5947-db18-4a1c-acb2-de51c005d4cc" />
